### PR TITLE
Allowing running `pip install` in `docker build` steps

### DIFF
--- a/keyrings/gauth.py
+++ b/keyrings/gauth.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import os
 
 import google
 from google.auth.transport import requests
@@ -39,6 +40,9 @@ class GooglePyPIAuth(backend.KeyringBackend):
     url = urlparse(service)
     if url.hostname is None or not url.hostname.endswith(".pkg.dev"):
       return
+
+    if os.environ.get("ARTIFACT_ACCESS_TOKEN"):
+      return os.environ["ARTIFACT_ACCESS_TOKEN"]
 
     #trying application default credentials otherwise fall back to gcloud credentials command
     try:


### PR DESCRIPTION
With the current version, `0.0.2`, if `pip install` is run from a `Dockerfile` as part of a `docker build` step, it will fail to install libraries stored in a private artifact repo.
With this change, it will be possible to fetch the access token from a "non-build" step, and pass it to the `docker build` step via `--build-arg`.

Add this step to your `cloudbuild.yaml`
```yaml
  - name: "gcr.io/cloud-builders/curl"
    waitFor: ["-"]
    id: "fetch-artifact-access-token"
    entrypoint: "bash"
    args:
      - "-c"
      - >
        apt-get update &&
        apt-get install -y jq &&
        curl -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token | jq -r .access_token > /workspace/.artifact_access_token
```

Add `--build-arg` to your `docker build` step, eg:
```yaml
  - name: "gcr.io/cloud-builders/docker"
    waitFor: [ "fetch-artifact-access-token" ]
    id: "docker-build"
    entrypoint: "bash"
    args:
      - "-c"
      - >
        docker build
        --quiet
        --cache-from gcr.io/$PROJECT_ID/my-image
        --file /workspace/my-project/Dockerfile
        --build-arg "artifact_access_token=$$(cat /workspace/.artifact_access_token)"
        -t gcr.io/$PROJECT_ID/my-image
        /workspace/my-project
```

Edit `Dockerfile` accordingly, eg:
```Dockerfile
ARG artifact_access_token

RUN pip install --upgrade \
    pip \
    keyring \
    git+https://github.com/ffissore/artifact-registry-pypi-tools.git#egg=keyrings.google-artifactregistry-auth

COPY ./requirements.txt /

RUN export ARTIFACT_ACCESS_TOKEN="$artifact_access_token" && \
    pip install \
    --extra-index-url=https://my-repo-url/simple/ \
    --requirement=/requirements.txt
```